### PR TITLE
Fixed page number not being maintained in URL

### DIFF
--- a/src/Kyslik/ColumnSortable/Sortable.php
+++ b/src/Kyslik/ColumnSortable/Sortable.php
@@ -43,7 +43,7 @@ trait Sortable
             'order' => Input::get('order') === 'asc' ? 'desc' : 'asc'
         ];
 
-        $url = route(Request::route()->getName(), array_merge(Request::route()->parameters(), $parameters));
+        $url = route(Request::route()->getName(), array_merge(Request::except(['order','sort']), $parameters));
 
         return '<a href="' . $url . '"' . '>' . htmlentities($title) . '</a>' . ' ' . '<i class="' . $icon . '"></i>';
     }


### PR DESCRIPTION
The current page number was not being maintained when using the `@sortablelink()` Blade extension. This fix maintains the current page number parameter in additional to setting `sort` and `order` parameters.