### PR TITLE
clickable icon

### DIFF
--- a/src/ColumnSortable/Sortable.php
+++ b/src/ColumnSortable/Sortable.php
@@ -137,7 +137,7 @@ trait Sortable
         $title = $parameters[1];
 
         $formatting_function = Config::get('columnsortable.formatting_function', null);
-        
+
         if (!is_null($formatting_function) && function_exists($formatting_function)) {
             $title = call_user_func($formatting_function, $title);
         }
@@ -175,7 +175,13 @@ trait Sortable
             $anchorClass = 'class="' . $anchorClass . '"';
         }
 
-        return '<a ' . $anchorClass . ' href="'. url(Request::path() . '?' . $queryString) . '"' . '>' . htmlentities($title) . '</a>' . ' ' . '<i class="' . $icon . '"></i>';
+        $clickableIcon = Config::get('columnsortable.clickable_icon', false);
+        $trailingTag = ' ' . '<i class="' . $icon . '"></i>' . '</a>' ;
+        if ($linkOnIcon == false) {
+            $trailingTag = '</a>' . ' ' . '<i class="' . $icon . '"></i>';
+        }
+
+        return '<a ' . $anchorClass . ' href="'. url(Request::path() . '?' . $queryString) . '"' . '>' . htmlentities($title) . $trailingTag;
     }
 
     /**

--- a/src/config/columnsortable.php
+++ b/src/config/columnsortable.php
@@ -31,6 +31,11 @@ return [
     'sortable_icon'    => 'fa fa-sort',
 
     /*
+     * icon is clickable or not
+     */
+    'clickable_icon' => false,
+
+    /*
     suffix class that is appended when ascending order is applied
     */
     'asc_suffix'        => '-asc',


### PR DESCRIPTION
As soon as I try out this package, I find that `icon`s are not clickable. Imaging the column `ID`, it's so tiny, and yet the icon next to it isn't help with clicking at all.

I added a config-param in `config.php`: `clickable_icon`. It is default to false like it used to be. For myself, I just set it to true to allow the icon clickable.

Thank you for reading.