### PR TITLE
Allow columns that have value of 0 to be present

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -58,7 +58,7 @@ class SortableLink
         $queryString = http_build_query(
             array_merge(
                 $queryParameters,
-                array_filter(Request::except('sort', 'order', 'page')),
+                array_filter(Request::except('sort', 'order', 'page'), 'strlen'),
                 [
                     'sort' => $sortParameter,
                     'order' => $direction,


### PR DESCRIPTION
Since array filter considers 0= false, and '0' = false, if you have a column with values 0 and 1, you can't sort that column, as it will be filtered out.
using the strlen filter, you ensure that values like null,empty and false are removed, but you keep values that would be boolean false in php, but they shouldn't.