### PR TITLE
Allow calling of relation's override methods

### DIFF
--- a/src/ColumnSortable/Sortable.php
+++ b/src/ColumnSortable/Sortable.php
@@ -58,10 +58,6 @@ trait Sortable
             return $query;
         }
 
-        if (method_exists($this, camel_case($column).'Sortable')) {
-            return call_user_func_array([$this, camel_case($column).'Sortable'], [$query, $direction]);
-        }
-
         $explodeResult = SortableLink::explodeSortParameter($column);
         if ( ! empty($explodeResult)) {
             $relationName = $explodeResult[0];
@@ -77,6 +73,10 @@ trait Sortable
             }
 
             $model = $relation->getRelated();
+        }
+
+        if (method_exists($model, camel_case($column).'Sortable')) {
+            return call_user_func_array([$model, camel_case($column).'Sortable'], [$query, $direction]);
         }
 
         if (isset($model->sortableAs) && in_array($column, $model->sortableAs)) {

--- a/tests/ColumnSortableTraitTest.php
+++ b/tests/ColumnSortableTraitTest.php
@@ -144,6 +144,18 @@ class ColumnSortableTraitTest extends \Orchestra\Testbench\TestCase
         $this->assertEquals($expectedQuery, $resultQuery);
     }
 
+    public function testSortableOverridingQueryOrderBuilderOnRelation()
+    {
+        $sortParameters = ['sort' => 'profile.composite', 'order' => 'desc'];
+        $query = $this->user->newQuery();
+
+        $resultQuery = $this->invokeMethod($this->user, 'queryOrderBuilder', [$query, $sortParameters]);
+
+        $expectedQuery = $this->user->newQuery()->join('profiles', 'users.id', '=',
+            'profiles.user_id')->orderBy('phone', 'desc')->orderBy('address', 'desc')->select('users.*');
+
+        $this->assertEquals($expectedQuery, $resultQuery);
+    }
 
     public function testSortableAs()
     {
@@ -314,7 +326,8 @@ class Profile extends Model
      */
     public $sortable = [
         'phone',
-        'address'
+        'address',
+        'composite'
     ];
 
 
@@ -324,5 +337,10 @@ class Profile extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function compositeSortable($query, $direction)
+    {
+        return $query->orderBy('phone', $direction)->orderBy('address', $direction);
     }
 }


### PR DESCRIPTION
I've noticed that related model's override methods aren't called. Only the parent model was being checked for any override methods. I've moved the code that checks for a `columnSortable` method to after the check for a related model.

Here's my use case.

```php
class Application extends Model
{
    use Sortable;

    /**
     * Sortable attributes.
     */
    public $sortable = [
        'reference',
        'created_at',
        'updated_at'
    ];

    /**
     * Get associated child.
     *
     * @return \Illuminate\Database\Eloquent\Relations\HasOne
     */
    public function child()
    {
        return $this->hasOne(Child::class);
    }
}
```

```php
class Child extends Model
{
    use Sortable;

    /**
     * Sortable attributes.
     */
    public $sortable = ['name'];

    /**
     * Get associated application.
     *
     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
     */
    public function application()
    {
        return $this->belongsTo(Application::class);
    }

    /**
     * Name sortable override.
     *
     * @param  \Illuminate\Database\Query\Builder  $query
     * @param  string                              $direction
     * @return \Illuminate\Database\Query\Builder
     */
    public function nameSortable(Builder $query, string $direction)
    {
        return $query->orderBy('forename', $direction)->orderBy('surname', $direction);
    }
}
```

The `Child::nameSortable` method will now be called when sorting by `child.name`
