### PR TITLE
add active and direction classes to SortableLink anchor

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -32,7 +32,7 @@ class SortableLink
 
         $trailingTag = self::formTrailingTag($icon);
 
-        $anchorClass = self::getAnchorClass();
+        $anchorClass = self::getAnchorClass($sortColumn, $direction);
 
         $queryString = self::buildQueryString($queryParameters, $sortParameter, $direction);
 
@@ -168,16 +168,47 @@ class SortableLink
 
 
     /**
+     * @param $sortColumn
+     * @param $direction
+     * 
      * @return string
      */
-    private static function getAnchorClass()
+    private static function getAnchorClass($sortColumn, $direction)
     {
+        $class = [];
+
         $anchorClass = Config::get('columnsortable.anchor_class', null);
         if ($anchorClass !== null) {
-            return ' class="'.$anchorClass.'"';
+            $class[] = $anchorClass;
         }
 
-        return '';
+        $activeClass = Config::get('columnsortable.active_anchor_class', null);
+        if ($activeClass !== null && self::shouldShowActive($sortColumn)) {
+            $class[] = $activeClass;
+        }
+
+        $orderClassPrefix = Config::get('columnsortable.order_anchor_class_prefix', null);
+        if ($orderClassPrefix !== null && self::shouldShowActive($sortColumn)) {
+            $class[] = $orderClassPrefix . (Request::get('order') === 'asc' ? Config::get('columnsortable.asc_suffix',
+                '-asc') : Config::get('columnsortable.desc_suffix', '-desc'));
+        }
+
+        return ' class="'.implode(' ', $class).'"';
+    }
+
+
+    /**
+     * @param $sortColumn
+     * 
+     * @return boolean
+     */
+    private static function shouldShowActive($sortColumn)
+    {
+        if (Request::has('sort')) {
+            return Request::get('sort') == $sortColumn;
+        }
+
+        return false;
     }
 
 

--- a/src/config/columnsortable.php
+++ b/src/config/columnsortable.php
@@ -57,6 +57,16 @@ return [
     'anchor_class'                  => null,
 
     /*
+    default active anchor class, if value is null none is added
+     */
+    'active_anchor_class'           => null,
+
+    /*
+    default sort order anchor class, if value is null none is added
+     */
+    'order_anchor_class_prefix'     => null,
+
+    /*
     relation - column separator ex: detail.phone_number means relation "detail" and column "phone_number"
      */
     'uri_relation_column_separator' => '.',


### PR DESCRIPTION
Adds an active class and a directional (asc/desc) class to the anchor generated in SortableLink that can be configured (or disabled) in the configuration file.

I needed this for a personal project and decided a bunch of @ifs in the view was a bit too hacky and also noticed you have an open issue discussing this feature (#58).