### PR TITLE
Allow HTML in titles, and option to disable formatting in all custom titles

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -3,6 +3,7 @@
 namespace Kyslik\ColumnSortable;
 
 use Kyslik\ColumnSortable\Exceptions\ColumnSortableException;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Str;
 
 /**
@@ -38,7 +39,7 @@ class SortableLink
 
         $queryString = self::buildQueryString($queryParameters, $sortParameter, $direction);
 
-        return '<a'.$anchorClass.' href="'.url(request()->path().'?'.$queryString).'"'.$anchorAttributesString.'>'.htmlentities($title).$trailingTag;
+        return '<a'.$anchorClass.' href="'.url(request()->path().'?'.$queryString).'"'.$anchorAttributesString.'>'.e($title).$trailingTag;
     }
 
 
@@ -90,12 +91,16 @@ class SortableLink
 
 
     /**
-     * @param string $title
+     * @param string|\Illuminate\Contracts\Support\Htmlable $title
      *
      * @return string
      */
     private static function applyFormatting($title)
     {
+        if ($title instanceof Htmlable) {
+            return $title;
+        }
+
         $formatting_function = config('columnsortable.formatting_function', null);
         if ( ! is_null($formatting_function) && function_exists($formatting_function)) {
             $title = call_user_func($formatting_function, $title);

--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -23,7 +23,7 @@ class SortableLink
     {
         list($sortColumn, $sortParameter, $title, $queryParameters, $anchorAttributes) = self::parseParameters($parameters);
 
-        $title = self::applyFormatting($title);
+        $title = self::applyFormatting($title, $sortColumn);
 
         if ($mergeTitleAs = config('columnsortable.inject_title_as', null)) {
             request()->merge([$mergeTitleAs => $title]);
@@ -55,7 +55,7 @@ class SortableLink
         //TODO: needs some checks before determining $title
         $explodeResult    = self::explodeSortParameter($parameters[0]);
         $sortColumn       = (empty($explodeResult)) ? $parameters[0] : $explodeResult[1];
-        $title            = (count($parameters) === 1) ? $sortColumn : $parameters[1];
+        $title            = (count($parameters) === 1) ? null : $parameters[1];
         $queryParameters  = (isset($parameters[2]) && is_array($parameters[2])) ? $parameters[2] : [];
         $anchorAttributes = (isset($parameters[3]) && is_array($parameters[3])) ? $parameters[3] : [];
 
@@ -91,13 +91,20 @@ class SortableLink
 
 
     /**
-     * @param string|\Illuminate\Contracts\Support\Htmlable $title
+     * @param string|\Illuminate\Contracts\Support\Htmlable|null $title
+     * @param string $sortColumn
      *
      * @return string
      */
-    private static function applyFormatting($title)
+    private static function applyFormatting($title, $sortColumn)
     {
         if ($title instanceof Htmlable) {
+            return $title;
+        }
+
+        if ($title === null) {
+            $title = $sortColumn;
+        } elseif ( ! config('columnsortable.format_custom_titles', true)){
             return $title;
         }
 

--- a/src/config/columnsortable.php
+++ b/src/config/columnsortable.php
@@ -82,6 +82,11 @@ return [
     'formatting_function'           => 'ucfirst',
 
     /*
+    apply formatting function to custom titles as well as column names
+     */
+    'format_custom_titles'          => true,
+
+    /*
     inject title parameter in query strings, use null to turn injection off
     example: 'inject_title' => 't' will result in ..user/?t="formatted title of sorted column"
      */

--- a/tests/SortableLinkTest.php
+++ b/tests/SortableLinkTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\HtmlString;
 use Kyslik\ColumnSortable\SortableLink;
 
 /**
@@ -53,11 +54,51 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
     }
 
 
+    public function testGeneratingTitle()
+    {
+        Config::set('columnsortable.formatting_function', 'ucfirst');
+        Config::set('columnsortable.format_custom_titles', true);
+        $link = SortableLink::render(['column']);
+
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc" >Column</a><i class=""></i>', $link);
+    }
+
+
+    public function testCustomTitle()
+    {
+        Config::set('columnsortable.formatting_function', 'ucfirst');
+        Config::set('columnsortable.format_custom_titles', true);
+        $link = SortableLink::render(['column', 'columnTitle']);
+
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc" >ColumnTitle</a><i class=""></i>', $link);
+    }
+
+
+    public function testCustomTitleWithoutFormatting()
+    {
+        Config::set('columnsortable.formatting_function', 'ucfirst');
+        Config::set('columnsortable.format_custom_titles', false);
+        $link = SortableLink::render(['column', 'columnTitle']);
+
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc" >columnTitle</a><i class=""></i>', $link);
+    }
+
+
+    public function testCustomTitleWithHTML()
+    {
+        Config::set('columnsortable.formatting_function', 'ucfirst');
+        Config::set('columnsortable.format_custom_titles', true);
+        $link = SortableLink::render(['column', new HtmlString('<em>columnTitle</em>')]);
+
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc" ><em>columnTitle</em></a><i class=""></i>', $link);
+    }
+
+
     public function testParseParameters()
     {
         $parameters  = ['column'];
         $resultArray = SortableLink::parseParameters($parameters);
-        $expected    = ['column', 'column', 'column', [], []];
+        $expected    = ['column', 'column', null, [], []];
         $this->assertEquals($expected, $resultArray);
 
         $parameters  = ['column', 'ColumnTitle'];
@@ -77,7 +118,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
 
         $parameters  = ['relation.column'];
         $resultArray = SortableLink::parseParameters($parameters);
-        $expected    = ['column', 'relation.column', 'column', [], []];
+        $expected    = ['column', 'relation.column', null, [], []];
         $this->assertEquals($expected, $resultArray);
 
         $parameters  = ['relation.column', 'ColumnTitle'];


### PR DESCRIPTION
Fixes #127, in the way I suggested in https://github.com/Kyslik/column-sortable/issues/127#issuecomment-546718374.

I split this into two commits in case you don't want the second part.

1. Support HTML titles - for example:

    ```html
    <th>@sortablelink('title', new Illuminate\Support\HtmlString('<em>Title with HTML</em>'))</th>
    ```

    This is achieved by (1) using `e()` instead of `htmlentities()`, and (2) skipping the formatting function so it's not converted to a string.

    (**Tip:** to shorten this to `new HtmlString(...)`, add `'HtmlString' => Illuminate\Support\HtmlString::class` to the `aliases` section in `config.app`.)

2. A config option to not apply the formatting function to any custom titles (including regular strings).

    Personally I'd be happy for it to never apply formatting to custom titles (I can't see a good use case for doing so), but I made it a config option that defaults to `true` so it's fully backwards-compatible. (I could remove that if you think it's unnecessary.)

Thanks!