### PR TITLE
Add support for MorphOne relationships

### DIFF
--- a/src/ColumnSortable/Exceptions/ColumnSortableException.php
+++ b/src/ColumnSortable/Exceptions/ColumnSortableException.php
@@ -17,7 +17,7 @@ class ColumnSortableException extends Exception
                 $message = 'Relation \''.$message.'\' does not exist.';
                 break;
             case 2:
-                $message = 'Relation \''.$message.'\' is not instance of HasOne or BelongsTo.'; //hasMany
+                $message = 'Relation \''.$message.'\' is not instance of HasOne, MorphOne, or BelongsTo.'; //hasMany
                 break;
         }
 


### PR DESCRIPTION
This PR adds support for sorting by a polymorphic `MorphOne` relationship.  This change is pretty straight-forward as it only requires an extra condition to the join query.

Let me know if you have any questions or would like me to revise or add anything.
