### PR TITLE
Change trailing tags to span

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -174,12 +174,13 @@ class SortableLink
 
         $iconAndTextSeparator = config('columnsortable.icon_text_separator', '');
 
+        $iconClass = config('columnsortable.icon_class', '');
+
         $clickableIcon = config('columnsortable.clickable_icon', false);
-        $trailingTag   = $iconAndTextSeparator.'<i class="'.$icon.'"></i>'.'</a>';
+        $trailingTag   = $iconAndTextSeparator.'<span class="'.$icon.' '.$iconClass.'"></span>'.'</a>';
 
         if ($clickableIcon === false) {
-            $trailingTag = '</a>'.$iconAndTextSeparator.'<i class="'.$icon.'"></i>';
-
+            $trailingTag = '</a>'.$iconAndTextSeparator.'<span class="'.$icon.' '.$iconClass.'"></span>';
             return $trailingTag;
         }
 


### PR DESCRIPTION
By changing the tags to `<span>`, and adding a related config option, this enables the icons to receive their own classes, not just be forced to be `<i>`
Initial testing shows it works well with tailwindcss classes.