### PR TITLE
Change formTrailingTag to use <span>

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -166,6 +166,7 @@ class SortableLink
      *
      * @return string
      */
+
     private static function formTrailingTag($icon)
     {
         if ( ! config('columnsortable.enable_icons', true)) {
@@ -174,11 +175,13 @@ class SortableLink
 
         $iconAndTextSeparator = config('columnsortable.icon_text_separator', '');
 
+        $iconClass = config('columnsortable.icon_class');
+
         $clickableIcon = config('columnsortable.clickable_icon', false);
-        $trailingTag   = $iconAndTextSeparator.'<i class="'.$icon.'"></i>'.'</a>';
+        $trailingTag   = $iconAndTextSeparator.'<span class="'.$icon.' '.$iconClass.'"></span>'.'</a>';
 
         if ($clickableIcon === false) {
-            $trailingTag = '</a>'.$iconAndTextSeparator.'<i class="'.$icon.'"></i>';
+            $trailingTag = '</a>'.$iconAndTextSeparator.'<span class="'.$icon.' '.$iconClass.'"></span>';
 
             return $trailingTag;
         }

--- a/src/config/columnsortable.php
+++ b/src/config/columnsortable.php
@@ -72,6 +72,12 @@ return [
     'direction_anchor_class_prefix' => null,
 
     /*
+    additional class to add to the icon class
+    Added to icons only, for title and icon together, use the anchor classes above)
+    */
+    'icon_class'                    => null,
+
+    /*
     relation - column separator ex: detail.phone_number means relation "detail" and column "phone_number"
      */
     'uri_relation_column_separator' => '.',

--- a/tests/SortableLinkTest.php
+++ b/tests/SortableLinkTest.php
@@ -57,7 +57,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
     {
         $link = SortableLink::render(['column', 'ColumnTitle', ['a' => 'b'], ['c' => 'd']]);
 
-        $this->assertSame('<a href="http://localhost?a=b&sort=column&direction=asc" c="d">ColumnTitle</a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?a=b&sort=column&direction=asc" c="d">ColumnTitle</a><span class=" "></span>', $link);
     }
 
     public function testGeneratingTitleWithoutFormattingFunction()
@@ -65,7 +65,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.formatting_function', null);
         $link = SortableLink::render(['column']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">column</a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">column</a><span class=" "></span>', $link);
     }
 
     public function testGeneratingTitle()
@@ -74,7 +74,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">Column</a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">Column</a><span class=" "></span>', $link);
     }
 
 
@@ -84,7 +84,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column', 'columnTitle']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">ColumnTitle</a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">ColumnTitle</a><span class=" "></span>', $link);
     }
 
 
@@ -94,7 +94,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', false);
         $link = SortableLink::render(['column', 'columnTitle']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">columnTitle</a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">columnTitle</a><span class=" "></span>', $link);
     }
 
 
@@ -104,7 +104,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column', new HtmlString('<em>columnTitle</em>')]);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc"><em>columnTitle</em></a><span class=""></span>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc"><em>columnTitle</em></a><span class=" "></span>', $link);
     }
 
 

--- a/tests/SortableLinkTest.php
+++ b/tests/SortableLinkTest.php
@@ -57,7 +57,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
     {
         $link = SortableLink::render(['column', 'ColumnTitle', ['a' => 'b'], ['c' => 'd']]);
 
-        $this->assertSame('<a href="http://localhost?a=b&sort=column&direction=asc" c="d">ColumnTitle</a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?a=b&sort=column&direction=asc" c="d">ColumnTitle</a><span class=""></span>', $link);
     }
 
     public function testGeneratingTitleWithoutFormattingFunction()
@@ -65,7 +65,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.formatting_function', null);
         $link = SortableLink::render(['column']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">column</a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">column</a><span class=""></span>', $link);
     }
 
     public function testGeneratingTitle()
@@ -74,7 +74,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">Column</a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">Column</a><span class=""></span>', $link);
     }
 
 
@@ -84,7 +84,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column', 'columnTitle']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">ColumnTitle</a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">ColumnTitle</a><span class=""></span>', $link);
     }
 
 
@@ -94,7 +94,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', false);
         $link = SortableLink::render(['column', 'columnTitle']);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">columnTitle</a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc">columnTitle</a><span class=""></span>', $link);
     }
 
 
@@ -104,7 +104,7 @@ class SortableLinkTest extends \Orchestra\Testbench\TestCase
         Config::set('columnsortable.format_custom_titles', true);
         $link = SortableLink::render(['column', new HtmlString('<em>columnTitle</em>')]);
 
-        $this->assertSame('<a href="http://localhost?sort=column&direction=asc"><em>columnTitle</em></a><i class=""></i>', $link);
+        $this->assertSame('<a href="http://localhost?sort=column&direction=asc"><em>columnTitle</em></a><span class=""></span>', $link);
     }
 
 


### PR DESCRIPTION
Change `<i>` tags to `<span>` to allow more granular setting of the icon class, especially when used within tailwindcss projects
Additional config option added to set the class for the icon span
Tests updated accordingly