### PR TITLE
Check if `sort` of request exists in array/db

### DIFF
--- a/src/ColumnSortable/Sortable.php
+++ b/src/ColumnSortable/Sortable.php
@@ -25,7 +25,7 @@ trait Sortable
      */
     public function scopeSortable($query, $defaultParameters = null)
     {
-        if (request()->allFilled(['sort', 'direction'])) { // allFilled() is macro
+        if (request()->allFilled(['sort', 'direction']) && $this->columnExists($this, request()->get('sort'))) { // allFilled() is macro
             return $this->queryOrderBuilder($query, request()->only(['sort', 'direction']));
         }
 


### PR DESCRIPTION
The user can manipulate the `sort` variable by entering a non-sortable value and in that case, the `$defaultParameters` should be applied.