### PR TITLE
Overriding the direction parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ There is a blade extension for you to use **@sortablelink()**
 
 You can omit 2nd, 3rd and 4th parameter.
 
+By using `['direction'=>'desc']` in 3rd parameter you can override the default toggle behavior.
+
 Possible examples and usages of blade extension:
 
 ```blade

--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -29,7 +29,7 @@ class SortableLink
             request()->merge([$mergeTitleAs => $title]);
         }
 
-        list($icon, $direction) = self::determineDirection($sortColumn, $sortParameter);
+        list($icon, $direction) = self::determineDirection($sortColumn, $sortParameter, $queryParameters);
 
         $trailingTag = self::formTrailingTag($icon);
 
@@ -125,14 +125,21 @@ class SortableLink
      *
      * @return array
      */
-    private static function determineDirection($sortColumn, $sortParameter)
+    private static function determineDirection($sortColumn, $sortParameter, $queryParameters)
     {
         $icon = self::selectIcon($sortColumn);
 
-        if (request()->get('sort') == $sortParameter && in_array(request()->get('direction'), ['asc', 'desc'])) {
-            $icon      .= (request()->get('direction') === 'asc' ? config('columnsortable.asc_suffix', '-asc') :
-                config('columnsortable.desc_suffix', '-desc'));
-            $direction = request()->get('direction') === 'desc' ? 'asc' : 'desc';
+        $override_direction = array_key_exists('direction', $queryParameters) && in_array($queryParameters['direction'], ['asc', 'desc']);
+
+        if (request()->get('sort') == $sortParameter && in_array(request()->get('direction'), ['asc', 'desc']) || $override_direction) {
+            $icon .= (request()->get('direction') === 'asc' ? config('columnsortable.asc_suffix', '-asc') : config('columnsortable.desc_suffix', '-desc'));
+
+            if($override_direction){ 
+                //Override the direction with the query parameter
+                $direction = $queryParameters['direction'];
+            }else{
+                $direction = request()->get('direction') === 'desc' ? 'asc' : 'desc';
+            }    
 
             return [$icon, $direction];
         } else {


### PR DESCRIPTION
 If the direction toggle in anchors is not what you want, e.g. you needed to have two different buttons for ASC and DESC, you can override the direction in the link as follows:

```html
<ul class="dropdown-menu pull-right">
    <li>@sortablelink('tag', 'Alphabetically [A-Z]', ['direction'=>'asc'])</li>
    <li>@sortablelink('tag', 'Reverse Alphabetically [Z-A]', ['direction'=>'desc'])</li>
    <li><a href="#">TBD: Most documents</a></li>
    <li><a href="#">TBD: Fewest documents</a></li>
    <li class="divider"></li>
    <li><a href="/tags">Reset (by Time Created)</a></li>
</ul>
```