### PR TITLE
Fix deprecated PHP 8.x passing null to strlen

### DIFF
--- a/src/ColumnSortable/SortableLink.php
+++ b/src/ColumnSortable/SortableLink.php
@@ -248,7 +248,7 @@ class SortableLink
     private static function buildQueryString($queryParameters, $sortParameter, $direction)
     {
         $checkStrlenOrArray = function ($element) {
-            return is_array($element) ? $element : strlen($element);
+            return is_array($element) ? $element : strlen($element ?? '');
         };
 
         $persistParameters = array_filter(request()->except('sort', 'direction', 'page'), $checkStrlenOrArray);


### PR DESCRIPTION
Since php 8.0 it has been deprecated to pass null as parameter to strlen.

When there are empty parameters in the querystring, this warning occurs:
`strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/kyslik/column-sortable/src/ColumnSortable/SortableLink.php on line 251`

This PR fixes this issue.
